### PR TITLE
Compatibility with ggplot2 3.6.0

### DIFF
--- a/tests/testthat/test-dicentrics.R
+++ b/tests/testthat/test-dicentrics.R
@@ -274,7 +274,13 @@ test_that("processing case data works", {
     aberr_name = to_title(aberr_module)
   )
 
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    labs <- ggplot2::get_labs(gg_curve)
+  } else {
+    labs <- gg_curve$labels
+  }
+
   # Expected outcomes
-  expect_equal(names(gg_curve$labels), c("colour", "shape", "x", "y", "ymin", "ymax"))
-  expect_equal(unname(unlist(gg_curve$labels)), c("Assessment", "Estimation", "Dose (Gy)", "Dicentrics/cells", "yield_low", "yield_upp"))
+  expect_in(c("colour", "shape", "x", "y", "ymin", "ymax"), names(labs))
+  expect_in(c("Assessment", "Estimation", "Dose (Gy)", "Dicentrics/cells", "yield_low", "yield_upp"), unname(unlist(labs)))
 })

--- a/tests/testthat/test-translocations.R
+++ b/tests/testthat/test-translocations.R
@@ -300,6 +300,12 @@ test_that("processing case data works", {
   )
 
   # Expected outcomes
-  expect_equal(names(gg_curve$labels), c("colour", "shape", "x", "y", "ymin", "ymax"))
-  expect_equal(unname(unlist(gg_curve$labels)), c("Assessment", "Estimation", "Dose (Gy)", "Translocations/cells", "yield_low", "yield_upp"))
+  if ("get_labs" %in% getNamespaceExports("ggplot2")) {
+    labs <- ggplot2::get_labs(gg_curve)
+  } else {
+    labs <- gg_curve$labels
+  }
+
+  expect_in(c("colour", "shape", "x", "y", "ymin", "ymax"), names(labs))
+  expect_in(c("Assessment", "Estimation", "Dose (Gy)", "Translocations/cells", "yield_low", "yield_upp"), unname(unlist(labs)))
 })


### PR DESCRIPTION
Hi there,

Apologies for not posting an issue first.
The ggplot2 package is planning an update for around May 2025 and a reverse dependency test identified a problem with the biodosetools package.
The details are explained in https://github.com/tidyverse/ggplot2/issues/6290, but essentially ggplot2 doesn't populate the `plot$labels` field before plot building anymore, which violates some test assumptions in this package.

This PR changes the tests to be compatible with both versions of ggplot2. 
You can test the changes yourself with the development version of ggplot2 (`pak::pak("tidyverse/ggplot2")`)

Best,
Teun