### PR TITLE
fix(config): use golem::pkg_path() instead of here::here() (golem 1.0.0 revdep)

### DIFF
--- a/inst/golem-config.yml
+++ b/inst/golem-config.yml
@@ -5,4 +5,4 @@ default:
 production:
   app_prod: yes
 dev:
-  golem_wd: !expr here::here()
+  golem_wd: !expr golem::pkg_path()


### PR DESCRIPTION
### Why

`{golem}` 1.0.0 (currently in CRAN submission) **removes `{here}` from its dependencies** — a documented breaking change ("Creating a `golem` no longer calls `set_here()` … the package is able to find its way using `DESCRIPTION`"). golem now resolves the project root through `golem::pkg_path()`.

This package's `inst/golem-config.yml` still defines the `dev` profile with `!expr here::here()`. While golem `Imports`-ed `here`, that expression evaluated fine during `R CMD check` because `here` was transitively installed. With golem 1.0.0 dropping `here`, it is no longer guaranteed to be present, so reading the `dev` profile fails:

```
Error in `config::get(...)`: Attempt to assign nested list value from expression.
Only directly assigned values can be used in expressions.
Original Error: loadNamespace(x): there is no package called 'here'
```

This surfaced in the golem 1.0.0 reverse-dependency check (`test-golem-recommended.R` → `get_golem_config("app_prod", config = "dev")`).

### Fix

Replace `!expr here::here()` with `!expr golem::pkg_path()` in `inst/golem-config.yml`. `golem::pkg_path()` is exported by golem (which this package already imports), so no new dependency is introduced — and the line now matches the current golem project template.

### Alternative

If you prefer to keep using `{here}`, add it to your `DESCRIPTION` `Imports`/`Suggests` instead. Switching to `golem::pkg_path()` is the lighter option and what golem now scaffolds by default.

---
Opened proactively as part of the golem 1.0.0 CRAN reverse-dependency follow-up. Thanks for maintaining this package! 🙏
